### PR TITLE
Change setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,7 @@ except (IOError, ImportError):
 package = 'tapioca_instagram'
 requirements = [
     'tapioca-wrapper<2',
-    'requests-oauthlib==0.4.2',
-    
+    'requests-oauthlib>=0.4.2',
 ]
 test_requirements = [
 


### PR DESCRIPTION
Hello there,

Following the same PR I did on https://github.com/vintasoftware/tapioca-wrapper/pull/112, the requests-oauthlib==0.4.2 is really outdated, today is 0.6.1.
Maybe the best solution is put 0.4.2 just as minimal dependency, not as required version.
